### PR TITLE
.gitmodules: change URLs from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "deltachat-core-rust"]
 	path = deltachat-core-rust
-	url = git@github.com:deltachat/deltachat-core-rust.git
+	url = https://github.com/deltachat/deltachat-core-rust
 [submodule "deltachat-node"]
 	path = deltachat-node
-	url = git@github.com:deltachat/deltachat-node.git
+	url = https://github.com/deltachat/deltachat-node
 	branch = rust_devmode_branch
 [submodule "deltachat-desktop"]
 	path = deltachat-desktop
-	url = git@github.com:deltachat/deltachat-desktop.git
+	url = https://github.com/deltachat/deltachat-desktop


### PR DESCRIPTION
Otherwise it is not usable by users outside deltachat organization.